### PR TITLE
chown /etc/telegraf to telegraf user (fix #4)

### DIFF
--- a/tasks/distribution/Linux/configuration.yml
+++ b/tasks/distribution/Linux/configuration.yml
@@ -6,6 +6,7 @@
   file:
     path: /etc/telegraf
     mode: 0750
+    owner: telegraf
     state: directory
 
 - name: Create /etc/telegraf.d directory
@@ -13,6 +14,7 @@
   file:
     path: /etc/telegraf/telegraf.d
     mode: 0750
+    owner: telegraf
     state: directory
 
 - name: 'Copy the template for versions >= 0.10.0'
@@ -21,6 +23,7 @@
     src: telegraf.conf.j2
     dest: '{{ telegraf_directory }}/telegraf.conf'
     mode: 0640
+    owner: telegraf
   when:
     - telegraf_version is version_compare('0.10.0', '>=')
   notify:


### PR DESCRIPTION
currently telegraf starts as telegraf user and cannot read /etc/telegraf

Signed-off-by: Gui Iribarren <gui@altermundi.net>